### PR TITLE
Merge branch `master` into `dev`

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -27,7 +27,6 @@ jobs:
           updated_content=$(echo "$updated_content" | sed 's/cxx_std_11/cxx_variadic_templates/g')
           echo "$updated_content" > "$file_path"
           cd ./external/lsplant/lsplant/src/main/jni/external/dex_builder
-          git fetch
           git checkout `git log -1 --format="%H"`
           git submodule update --init --recursive
 

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -26,11 +26,11 @@ jobs:
           updated_content=$(echo "$file_content" | sed 's/option(FMT_INSTALL "Generate the install target." ON)/option(FMT_INSTALL "Generate the install target." ${FMT_MASTER_PROJECT})/')
           updated_content=$(echo "$updated_content" | sed 's/cxx_std_11/cxx_variadic_templates/g')
           echo "$updated_content" > "$file_path"
-          cd ./external/lsplant/lsplant/
+          cd ./external/lsplant/
           git rm --cached "test/src/main/jni/external/lsparself"
           git rm --cached "test/src/main/jni/external/lsprism"
           git submodule update --init --recursive --no-fetch --checkout
-          cd ./src/main/jni/external/dex_builder/external/parallel_hashmap/parallel_hashmap/
+          cd ./lsplant/src/main/jni/external/dex_builder/external/parallel_hashmap/parallel_hashmap/
 
       - name: Write key
         if: ${{ ( github.event_name != 'pull_request' && github.ref == 'refs/heads/master' ) || github.ref_type == 'tag' }}

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -32,7 +32,6 @@ jobs:
           echo "$updated_content" > "$file_path"
           cd ./external/lsplant/lsplant/src/main/jni/external/dex_builder
           git fetch
-          git checkout master
           git submodule update --init --recursive
 
       - name: Write key

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -27,7 +27,7 @@ jobs:
           updated_content=$(echo "$updated_content" | sed 's/cxx_std_11/cxx_variadic_templates/g')
           echo "$updated_content" > "$file_path"
           cd ./external/lsplant/lsplant/src/main/jni/external/dex_builder
-          git checkout `git log -1 --format="%H"`
+          git checkout 9d57844a301077abf4c29e061b2458c56a363c8f
           git submodule update --init --recursive
 
       - name: Write key

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -19,10 +19,6 @@ jobs:
           submodules: "recursive"
           fetch-depth: 0
 
-      - name: Initialize Submodules
-        continue-on-error: true
-        run: git submodule update --init --recursive
-
       - name: Patch bad submodules
         run: |
           file_path="./external/fmt/CMakeLists.txt"

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -27,9 +27,8 @@ jobs:
           updated_content=$(echo "$updated_content" | sed 's/cxx_std_11/cxx_variadic_templates/g')
           echo "$updated_content" > "$file_path"
           cd ./external/lsplant/lsplant/
-          git submodule init
-          cd ./src/main/jni/external/dex_builder/
-          git submodule init
+          git submodule update --init --recursive --no-fetch --checkout
+          cd ./src/main/jni/external/dex_builder/external/parallel_hashmap/parallel_hashmap/
 
       - name: Write key
         if: ${{ ( github.event_name != 'pull_request' && github.ref == 'refs/heads/master' ) || github.ref_type == 'tag' }}

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -26,9 +26,10 @@ jobs:
           updated_content=$(echo "$file_content" | sed 's/option(FMT_INSTALL "Generate the install target." ON)/option(FMT_INSTALL "Generate the install target." ${FMT_MASTER_PROJECT})/')
           updated_content=$(echo "$updated_content" | sed 's/cxx_std_11/cxx_variadic_templates/g')
           echo "$updated_content" > "$file_path"
-          cd ./external/lsplant/lsplant/src/main/jni/external/dex_builder
-          git checkout 9d57844a301077abf4c29e061b2458c56a363c8f
-          git submodule update --init --recursive
+          cd ./external/lsplant/lsplant/
+          git submodule init
+          cd ./src/main/jni/external/dex_builder/
+          git submodule init
 
       - name: Write key
         if: ${{ ( github.event_name != 'pull_request' && github.ref == 'refs/heads/master' ) || github.ref_type == 'tag' }}

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -28,7 +28,7 @@ jobs:
           echo "$updated_content" > "$file_path"
           cd ./external/lsplant/lsplant/src/main/jni/external/dex_builder
           git fetch
-          git checkout HEAD
+          git checkout `git log -1 --format="%H"`
           git submodule update --init --recursive
 
       - name: Write key

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -27,6 +27,8 @@ jobs:
           updated_content=$(echo "$updated_content" | sed 's/cxx_std_11/cxx_variadic_templates/g')
           echo "$updated_content" > "$file_path"
           cd ./external/lsplant/lsplant/
+          git rm --cached "test/src/main/jni/external/lsparself"
+          git rm --cached "test/src/main/jni/external/lsprism"
           git submodule update --init --recursive --no-fetch --checkout
           cd ./src/main/jni/external/dex_builder/external/parallel_hashmap/parallel_hashmap/
 

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -32,6 +32,7 @@ jobs:
           echo "$updated_content" > "$file_path"
           cd ./external/lsplant/lsplant/src/main/jni/external/dex_builder
           git fetch
+          git checkout HEAD
           git submodule update --init --recursive
 
       - name: Write key

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,7 @@ val androidTargetSdkVersion by extra(34)
 val androidMinSdkVersion by extra(27)
 val androidBuildToolsVersion by extra("34.0.0")
 val androidCompileSdkVersion by extra(34)
-val androidCompileNdkVersion by extra("27.0.11718014-beta1")
+val androidCompileNdkVersion by extra("26.1.10909125")
 val androidSourceCompatibility by extra(JavaVersion.VERSION_17)
 val androidTargetCompatibility by extra(JavaVersion.VERSION_17)
 


### PR DESCRIPTION
This action is usually unnecessary because the developers can:
1. delete branch `dev`
2. make new changes on the local repository
3. make the commits ahead into another brand new branch `dev`
4. make a pull request from `dev` to `master`

Here, the developer becomes lazy and reuses this old branch.