### PR TITLE
build(deps): upgrade AGP to 8.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.2.1"
+agp = "8.5.0"
 kotlin = "1.9.22"
 nav = "2.7.6"
 appcenter = "5.0.4"

--- a/magisk-loader/proguard-rules.pro
+++ b/magisk-loader/proguard-rules.pro
@@ -15,3 +15,6 @@
 -repackageclasses
 -allowaccessmodification
 -dontwarn org.slf4j.impl.StaticLoggerBinder
+-dontwarn org.lsposed.lspd.core.ApplicationServiceClient
+-dontwarn org.lsposed.lspd.core.Startup
+-dontwarn org.lsposed.lspd.util.Hookers


### PR DESCRIPTION
This is required by LSPatch, Kotlin 1.9.24 and Java 21.