### PR TITLE
fix: failed to optimize

### DIFF
--- a/core/proguard-rules.pro
+++ b/core/proguard-rules.pro
@@ -31,3 +31,6 @@
 -repackageclasses
 -allowaccessmodification
 -dontwarn org.slf4j.impl.StaticLoggerBinder
+-keep class org.lsposed.lspd.core.** { *; }
+-keep class org.lsposed.lspd.util.** { *; }
+-keep class org.lsposed.lspd.impl.** { *; }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 nav-safeargs = { id = "androidx.navigation.safeargs", version.ref = "nav" }
 autoresconfig = { id = "dev.rikka.tools.autoresconfig", version = "1.2.2" }
 materialthemebuilder = { id = "dev.rikka.tools.materialthemebuilder", version = "1.4.1" }
-lsplugin-resopt = { id = "org.lsposed.lsplugin.resopt", version = "1.5" }
+lsplugin-resopt = { id = "org.lsposed.lsplugin.resopt", version = "1.6" }
 lsplugin-apksign = { id = "org.lsposed.lsplugin.apksign", version = "1.4" }
 lsplugin-cmaker = { id = "org.lsposed.lsplugin.cmaker", version = "1.2" }
 lsplugin-jgit = { id = "org.lsposed.lsplugin.jgit", version = "1.1" }

--- a/magisk-loader/build.gradle.kts
+++ b/magisk-loader/build.gradle.kts
@@ -200,7 +200,7 @@ fun afterEval() = android.applicationVariants.forEach { variant ->
             rename(".*\\.apk", "daemon.apk")
         }
         into("lib") {
-            from(layout.buildDirectory.dir("intermediates/stripped_native_libs/$variantCapped/out/lib")) {
+            from(layout.buildDirectory.dir("intermediates/stripped_native_libs/$variantCapped/strip${variantCapped}DebugSymbols/out/lib")) {
                 include("**/liblspd.so")
             }
         }

--- a/magisk-loader/proguard-rules.pro
+++ b/magisk-loader/proguard-rules.pro
@@ -15,6 +15,6 @@
 -repackageclasses
 -allowaccessmodification
 -dontwarn org.slf4j.impl.StaticLoggerBinder
--dontwarn org.lsposed.lspd.core.ApplicationServiceClient
--dontwarn org.lsposed.lspd.core.Startup
--dontwarn org.lsposed.lspd.util.Hookers
+-keep class org.lsposed.lspd.core.** { *; }
+-keep class org.lsposed.lspd.util.** { *; }
+-keep class org.lsposed.lspd.impl.** { *; }


### PR DESCRIPTION
fix: failed to optimize resources by upgrading org.lsposed.lsplugin.resopt.

fix: lib not found in the packaged zip by modifying *.so including path.

fix: R8 minifying failed and no such class/method error during boot by no longer minifying org.lsposed.lspd.* classes.
